### PR TITLE
Add RSS link in HTML head

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -48,6 +48,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <link rel="icon" href="/favicon.png" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="alternate" type="application/rss+xml" href="/rss" />
       </head>
       <body className="antialiased max-w-xl mx-4 mt-8 lg:mx-auto">
         <main className="flex-auto min-w-0 mt-6 flex flex-col px-2 md:px-0">

--- a/app/rss/route.ts
+++ b/app/rss/route.ts
@@ -36,7 +36,7 @@ export async function GET() {
 
   return new Response(rssFeed, {
     headers: {
-      'Content-Type': 'text/xml',
+      'Content-Type': 'application/rss+xml',
     },
   })
 }


### PR DESCRIPTION
Adiciona link do feed RSS no head das páginas para facilitar encontrá-lo.

Para entender melhor como o RSS funciona, recomendo o texto [Descentralização de consumo na internet](https://blog.dunossauro.com/posts/descentralizacao-de-consumo-na-internet/) do @dunossauro.