### PR TITLE
Corrige cor do texto quando o navegador está com tema claro

### DIFF
--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -13,30 +13,16 @@
   --sh-class: #5F4B64;
   --sh-identifier: #FFF6FF;
   --sh-sign: #8996a3;
-  --sh-string: #007f7a;
-  --sh-keyword: #e02518;
+  --sh-string: #0fa295;
+  --sh-keyword: #f47067;
   --sh-comment: #a19595;
   --sh-jsxliterals: #6266d1;
   --sh-property: #e25a1c;
   --sh-entity: #e25a1c;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --sh-class: #5F4B64;
-    --sh-identifier: #FFF6FF;
-    --sh-keyword: #f47067;
-    --sh-string: #0fa295;
-  }
-
-  html {
-    color-scheme: dark;
-    background-color: var(--bg-color);
-    color: var(--text-color);
-  }
-}
-
 html {
+  color-scheme: dark;
   min-width: 360px;
   background-color: var(--bg-color);
   color: var(--text-color);


### PR DESCRIPTION
Quando o blog é acessado de um navegador usando tema claro, alguns textos aparecem com cor escura, mas como a cor de fundo não é ajustada, a falta de contraste pode dificultar a leitura:

![site-claro](https://github.com/user-attachments/assets/6b19c778-d7e1-4fc4-b078-2e56aec94860)

Enquanto quando acessado usando tema escuro, a leitura é muito mais fácil:

![site-escuro](https://github.com/user-attachments/assets/7cc437a9-f367-42bf-b28e-2691de3d5320)

Esse PR remove as regras que deixavam esses textos escuros, e serve como uma solução paliativa enquanto um tema claro pode ser desenvolvido no futuro.